### PR TITLE
Add a function to wait for events

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bt-embedded"]
+	path = bt-embedded
+	url = https://github.com/embedded-game-controller/bt-embedded.git

--- a/embedded-game-controller/CMakeLists.txt
+++ b/embedded-game-controller/CMakeLists.txt
@@ -6,6 +6,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Starlet")
         backends/ogc.c
         backends/ogc_arm.c
     )
+    list(APPEND EXTRA_LIBS gcc)
 elseif(CMAKE_SYSTEM_NAME MATCHES "NintendoWii")
     set(PLATFORM_SOURCES
         backends/wii.c
@@ -39,5 +40,4 @@ target_link_options(embedded-game-controller PRIVATE
 
 target_link_libraries(embedded-game-controller PRIVATE
     ${EXTRA_LIBS}
-    gcc
 )

--- a/embedded-game-controller/backends/libusb.c
+++ b/embedded-game-controller/backends/libusb.c
@@ -282,15 +282,14 @@ static const egc_usb_devdesc_t *lu_get_device_descriptor(egc_input_device_t *inp
     return &device->usbdesc;
 }
 
-static int lu_handle_events()
+/* Invoke any expired timers and return the number of microseconds until the next trigger */
+static int64_t invoke_timers()
 {
-    struct timeval tv = { 0, 0 };
-    libusb_handle_events_timeout_completed(s_libusb_ctx, &tv, NULL);
-
-    /* Check for expired timers */
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
     int64_t now = timespec_to_us(&ts);
+    int64_t min_timeout = INT64_MAX;
+
     for (int i = 0; i < ARRAY_SIZE(s_devices); i++) {
         lu_device_t *device = &s_devices[i];
         if (device->pub.connection == EGC_CONNECTION_DISCONNECTED)
@@ -298,8 +297,13 @@ static int lu_handle_events()
         if (device->timer_us <= 0)
             continue;
 
-        if (now < device->timer_us)
+        int64_t remaining_us = device->timer_us - now;
+        if (remaining_us > 0) {
+            if (remaining_us < min_timeout) {
+                min_timeout = remaining_us;
+            }
             continue;
+        }
 
         /* timer has expired, invoke the callback */
         bool keep = device->timer_callback(&device->pub);
@@ -311,7 +315,22 @@ static int lu_handle_events()
             device->repeat_timer_us = 0;
         }
     }
-    return 0;
+
+    return min_timeout;
+}
+
+static int lu_wait_events(u32 timeout_us)
+{
+    int64_t next_timer_us = invoke_timers();
+    if (next_timer_us < timeout_us)
+        timeout_us = next_timer_us;
+
+    int completed = 0;
+    struct timeval tv = { timeout_us / 1000000, timeout_us % 1000000 };
+    libusb_handle_events_timeout_completed(s_libusb_ctx, &tv, &completed);
+
+    invoke_timers();
+    return completed;
 }
 
 const egc_platform_backend_t _egc_platform_backend = {
@@ -324,5 +343,5 @@ const egc_platform_backend_t _egc_platform_backend = {
     .alloc_desc = lu_alloc_desc,
     .set_timer = lu_set_timer,
     .report_input = lu_report_input,
-    .handle_events = lu_handle_events,
+    .wait_events = lu_wait_events,
 };

--- a/embedded-game-controller/backends/ogc.c
+++ b/embedded-game-controller/backends/ogc.c
@@ -98,21 +98,11 @@ static egc_device_description_t s_device_descriptions[MAX_ACTIVE_DEVICES];
  * not called often enough, the queue might fill and events will be lost. */
 #define OGC_MAX_EVENTS 32
 
-typedef struct ogc_event_queue_t {
-    struct ogc_event_t {
-        egc_event_e type;
-        u8 device_index;
-    } ATTRIBUTE_PACKED events[OGC_MAX_EVENTS];
-    u8 current_index;
-} ATTRIBUTE_PACKED ogc_event_queue_t;
-static ogc_event_queue_t s_ogc_event_queue;
-
 static ogc_device_t s_devices[MAX_ACTIVE_DEVICES] ATTRIBUTE_ALIGN(32);
 static egc_usb_device_entry_t device_change_devices[USB_MAX_DEVICES] ATTRIBUTE_ALIGN(32);
 static ogc_transfer_t s_transfers[MAX_ACTIVE_TRANSFERS] ATTRIBUTE_ALIGN(32);
 static int host_fd = -1;
-static u8 worker_thread_stack[1024] ATTRIBUTE_ALIGN(32);
-static u32 queue_data[32] ATTRIBUTE_ALIGN(32);
+static u32 queue_data[OGC_MAX_EVENTS] ATTRIBUTE_ALIGN(32);
 static int queue_id = -1;
 static egc_event_cb s_event_handler;
 
@@ -371,21 +361,17 @@ static int ogc_report_input(egc_input_device_t *device, const egc_input_state_t 
     return 0;
 }
 
-static bool queue_event(egc_event_e type, ogc_device_t *device)
+static bool report_event(egc_event_e type, ogc_device_t *device)
 {
-    if (s_ogc_event_queue.current_index >= OGC_MAX_EVENTS) {
-        LOG_INFO("OGC event queue is full!");
-        return false;
+    bool ok = false;
+    if (type == EGC_EVENT_DEVICE_ADDED) {
+        int ret = s_event_handler(&device->pub, type, device->usb.vid, device->usb.pid);
+        ok = (ret == 0);
+    } else if (type == EGC_EVENT_DEVICE_REMOVED) {
+        s_event_handler(&device->pub, type);
+        ok = true;
     }
-
-    u8 device_index = device - s_devices;
-
-    enter_critical_section();
-    struct ogc_event_t *e = &s_ogc_event_queue.events[s_ogc_event_queue.current_index++];
-    e->type = type;
-    e->device_index = device_index;
-    leave_critical_section();
-    return true;
+    return ok;
 }
 
 static void ogc_device_free(ogc_device_t *device)
@@ -438,13 +424,8 @@ static void handle_device_change_reply(int host_fd, areply *reply)
                       " got disconnected\n",
                       device->usb.vid, device->usb.pid, device->usb.dev_id);
 
-            if (!queue_event(EGC_EVENT_DEVICE_REMOVED, device)) {
-                /* We normally mark the device as not valid only after the
-                 * client has retrieved the event, but since we couldn't add
-                 * the event into the queue, let's mark the device as available
-                 * here. */
-                ogc_device_free(device);
-            }
+            report_event(EGC_EVENT_DEVICE_REMOVED, device);
+            ogc_device_free(device);
         }
     }
 
@@ -493,7 +474,10 @@ static void handle_device_change_reply(int host_fd, areply *reply)
         device->timer_callback = NULL;
         device->pub.connection = EGC_CONNECTION_USB;
 
-        queue_event(EGC_EVENT_DEVICE_ADDED, device);
+        if (!report_event(EGC_EVENT_DEVICE_ADDED, device)) {
+            usb_hid_v5_release(host_fd, device->usb.dev_id);
+            device->pub.connection = EGC_CONNECTION_DISCONNECTED;
+        }
     }
 
     ret = os_ioctl_async(host_fd, USBV5_IOCTL_ATTACHFINISH, NULL, 0, NULL, 0, queue_id,
@@ -501,13 +485,12 @@ static void handle_device_change_reply(int host_fd, areply *reply)
     LOG_DEBUG("ioctl(ATTACHFINISH): %d\n", ret);
 }
 
-static int usb_hid_worker(void *arg)
+static int usb_hid_init()
 {
     u32 ver[8] ATTRIBUTE_ALIGN(32);
-    ogc_device_t *device;
     int ret;
 
-    LOG_DEBUG("usb_hid_worker thread started\n");
+    LOG_DEBUG("usb_hid_init\n");
 
     for (int i = 0; i < ARRAY_SIZE(s_devices); i++)
         s_devices[i].pub.connection = EGC_CONNECTION_DISCONNECTED;
@@ -529,13 +512,30 @@ static int usb_hid_worker(void *arg)
     ret = os_ioctl_async(host_fd, USBV5_IOCTL_GETDEVICECHANGE, NULL, 0, device_change_devices,
                          sizeof(device_change_devices), queue_id, MESSAGE_DEVCHANGE);
 
+    return ret;
+}
+
+static int process_queue(u32 timeout_us)
+{
+    ogc_device_t *device;
+    int ret;
+
+    s32 timer_id = -1;
+    u32 queue_flags;
+    if (timeout_us) {
+        timer_id = os_create_timer(timeout_us, 0, queue_id, (s32)&timer_id);
+        queue_flags = IOS_MESSAGE_BLOCK;
+    } else {
+        queue_flags = IOS_MESSAGE_NOBLOCK;
+    }
+
     while (1) {
         void *message;
 
         /* Wait for a message from USB devices */
-        ret = os_message_queue_receive(queue_id, &message, IOS_MESSAGE_BLOCK);
+        ret = os_message_queue_receive(queue_id, &message, queue_flags);
         if (ret != IOS_OK)
-            continue;
+            break;
 
         if (message == MESSAGE_DEVCHANGE) {
             handle_device_change_reply(host_fd, message);
@@ -543,6 +543,9 @@ static int usb_hid_worker(void *arg)
             ret =
                 os_ioctl_async(host_fd, USBV5_IOCTL_GETDEVICECHANGE, NULL, 0, device_change_devices,
                                sizeof(device_change_devices), queue_id, MESSAGE_DEVCHANGE);
+        } else if (message == &timer_id) {
+            /* Timer triggered, give up */
+            break;
         } else if ((areply *)message >= &s_transfers[0].reply &&
                    (areply *)message <= &s_transfers[ARRAY_SIZE(s_transfers) - 1].reply) {
             /* It's a transfer reply */
@@ -581,8 +584,15 @@ static int usb_hid_worker(void *arg)
                 }
             }
         }
+
+        /* If we got a message and have the timer set, don't iterate the loop again */
+        if (timer_id != -1)
+            break;
     }
 
+    if (timer_id != -1) {
+        os_destroy_timer(timer_id);
+    }
     return 0;
 }
 
@@ -597,12 +607,9 @@ static int ogc_init(egc_event_cb event_handler)
         return ret;
     queue_id = ret;
 
-    /* Worker USB HID thread that receives and dispatches async events */
-    ret = os_thread_create(usb_hid_worker, NULL, &worker_thread_stack[sizeof(worker_thread_stack)],
-                           sizeof(worker_thread_stack), 0, 0);
+    ret = usb_hid_init();
     if (ret < 0)
         return ret;
-    os_thread_continue(ret);
 
     return 0;
 }
@@ -631,33 +638,9 @@ static int ogc_set_suspended(egc_input_device_t *input_device, bool suspended)
     return usb_hid_v5_suspend_resume(device->usb.host_fd, device->usb.dev_id, !suspended);
 }
 
-static int ogc_handle_events()
+static int ogc_wait_events(u32 timeout_us)
 {
-    ogc_event_queue_t queue;
-    /* Create a copy of the queue to ensure it doesn't get modified while we
-     * process it */
-    enter_critical_section();
-    memcpy(&queue, &s_ogc_event_queue, sizeof(queue));
-    s_ogc_event_queue.current_index = 0; /* empty the queue */
-    leave_critical_section();
-
-    for (int i = 0; i < queue.current_index; i++) {
-        struct ogc_event_t *event = &queue.events[i];
-        ogc_device_t *device = &s_devices[event->device_index];
-
-        if (event->type == EGC_EVENT_DEVICE_ADDED) {
-            int ret = s_event_handler(&device->pub, event->type, device->usb.vid, device->usb.pid);
-            if (ret != 0) {
-                usb_hid_v5_release(host_fd, device->usb.dev_id);
-                device->pub.connection = EGC_CONNECTION_DISCONNECTED;
-            }
-        } else if (event->type == EGC_EVENT_DEVICE_REMOVED) {
-            s_event_handler(&device->pub, event->type);
-            /* Mark this device as not valid */
-            ogc_device_free(device);
-        }
-    }
-    return queue.current_index;
+    return process_queue(timeout_us);
 }
 
 const egc_platform_backend_t _egc_platform_backend = {
@@ -671,5 +654,5 @@ const egc_platform_backend_t _egc_platform_backend = {
     .alloc_desc = ogc_alloc_desc,
     .set_timer = ogc_set_timer,
     .report_input = ogc_report_input,
-    .handle_events = ogc_handle_events,
+    .wait_events = ogc_wait_events,
 };

--- a/embedded-game-controller/backends/wii.c
+++ b/embedded-game-controller/backends/wii.c
@@ -1,12 +1,12 @@
 #include <assert.h>
-#include <ogc/lwp.h>
 #include <ogc/machine/processor.h>
-#include <ogc/message.h>
-#include <ogc/mutex.h>
 #include <ogc/system.h>
 #include <ogc/usb.h>
 #include <stdio.h>
 #include <string.h>
+#include <tuxedo/mailbox.h>
+#include <tuxedo/ppc/clock.h>
+#include <tuxedo/tick.h>
 
 #include "platform.h"
 #include "utils.h"
@@ -39,9 +39,7 @@ typedef struct {
         // TODO: add bluetooth data here
     };
     egc_input_state_t next_input;
-    /* This mutex ensures that the input report is always updated in full */
-    mutex_t next_input_mutex;
-    syswd_t timer_id;
+    KTickTask timer_task;
     egc_timer_cb timer_callback;
 } wii_device_t;
 
@@ -63,25 +61,16 @@ typedef enum {
     WII_EVENT_GOT_INPUT,
 } wii_event_e;
 
-typedef struct wii_event_queue_t {
-    struct wii_event_t {
-        wii_event_e type;
-        u8 device_index;
-    } ATTRIBUTE_PACKED events[WII_MAX_EVENTS];
-    u8 current_index;
-} ATTRIBUTE_PACKED wii_event_queue_t;
-static wii_event_queue_t s_event_queue;
-static mutex_t s_event_queue_mutex;
-
 static wii_device_t s_devices[MAX_ACTIVE_DEVICES] ATTRIBUTE_ALIGN(32);
 static wii_transfer_t s_transfers[MAX_ACTIVE_TRANSFERS] ATTRIBUTE_ALIGN(32);
-static mqbox_t s_worker_queue;
-static lwp_t s_worker_thread;
+static KMailbox s_worker_queue;
+static uptr s_worker_queue_slots[10];
 static egc_event_cb s_event_handler;
 
+static void wii_device_free(wii_device_t *device);
 static int update_device_list(void);
-#define MSG_UPDATE_DEVICES_LIST ((mqmsg_t)update_device_list)
-#define MSG_FROM_TRANSFER(t)    ((mqmsg_t)t)
+#define MSG_UPDATE_DEVICES_LIST ((uptr)update_device_list)
+#define MSG_FROM_TRANSFER(t)    ((uptr)t)
 
 static inline wii_device_t *wii_device_from_input_device(egc_input_device_t *input_device)
 {
@@ -137,7 +126,7 @@ static s32 wii_transfer_cb(s32 result, void *userdata)
         transfer->t.status = EGC_USB_TRANSFER_STATUS_ERROR;
         transfer->t.length = 0;
     }
-    MQ_Send(s_worker_queue, MSG_FROM_TRANSFER(transfer), MQ_MSG_NOBLOCK);
+    KMailboxTrySend(&s_worker_queue, MSG_FROM_TRANSFER(transfer));
     return result;
 }
 
@@ -203,56 +192,42 @@ static const egc_usb_transfer_t *wii_intr_transfer_async(egc_input_device_t *inp
 
 /* This is called from an interrupt: do nothing in here, just send the event to
  * the worker thread */
-static void timer_cb(syswd_t timer_id, void *userdata)
+static void timer_cb(KTickTask *timer)
 {
-    wii_device_t *device = userdata;
-    MQ_Send(s_worker_queue, &device->timer_id, MQ_MSG_NOBLOCK);
-}
-
-static void us_to_timespec(int time_us, struct timespec *ts)
-{
-    ts->tv_sec = time_us / 1000000;
-    ts->tv_nsec = (time_us % 1000000) * 1000;
+    KMailboxTrySend(&s_worker_queue, (uptr)timer);
 }
 
 static int wii_set_timer(egc_input_device_t *input_device, int time_us, int repeat_time_us,
                          egc_timer_cb callback)
 {
     wii_device_t *device = (wii_device_t *)input_device;
-    struct timespec time0, time1;
-    int rc;
 
-    if (device->timer_id != 0) {
-        SYS_CancelAlarm(device->timer_id);
-    } else {
-        SYS_CreateAlarm(&device->timer_id);
+    if (device->timer_task.fn != NULL) {
+        KTickTaskStop(&device->timer_task);
     }
 
-    us_to_timespec(time_us, &time0);
-    if (repeat_time_us > 0) {
-        us_to_timespec(repeat_time_us, &time1);
-        rc = SYS_SetPeriodicAlarm(device->timer_id, &time0, &time1, timer_cb, device);
-    } else {
-        rc = SYS_SetAlarm(device->timer_id, &time0, timer_cb, device);
-    }
+    u64 timeout_ticks = PPCUsToTicks(time_us);
+    u64 period_ticks = (repeat_time_us > 0) ? PPCUsToTicks(repeat_time_us) : 0;
+    KTickTaskStart(&device->timer_task, timer_cb, timeout_ticks, period_ticks);
     device->timer_callback = callback;
-    return rc == 0 ? 0 : -1;
+    return 0;
 }
 
-static bool queue_event(egc_event_e type, wii_device_t *device)
+static bool report_event(wii_event_e type, wii_device_t *device)
 {
-    if (s_event_queue.current_index >= WII_MAX_EVENTS) {
-        LOG_INFO("WII event queue is full!");
-        return false;
+    if (type == WII_EVENT_DEVICE_ADDED) {
+        int ret = s_event_handler(&device->pub, EGC_EVENT_DEVICE_ADDED, device->usb.dev.vid,
+                                  device->usb.dev.pid);
+        if (ret != 0) {
+            wii_device_free(device);
+        }
+    } else if (type == WII_EVENT_DEVICE_REMOVED) {
+        s_event_handler(&device->pub, EGC_EVENT_DEVICE_REMOVED);
+        /* Mark this device as not valid */
+        wii_device_free(device);
+    } else if (type == WII_EVENT_GOT_INPUT) {
+        memcpy(&device->pub.state, &device->next_input, sizeof(device->next_input));
     }
-
-    u8 device_index = device - s_devices;
-
-    LWP_MutexLock(s_event_queue_mutex);
-    struct wii_event_t *e = &s_event_queue.events[s_event_queue.current_index++];
-    e->type = type;
-    e->device_index = device_index;
-    LWP_MutexUnlock(s_event_queue_mutex);
     return true;
 }
 
@@ -260,11 +235,6 @@ static void wii_device_free(wii_device_t *device)
 {
     if (device->usb.fd >= 0) {
         USB_CloseDevice(&device->usb.fd);
-    }
-
-    if (device->next_input_mutex != 0) {
-        LWP_MutexDestroy(device->next_input_mutex);
-        device->next_input_mutex = 0;
     }
 
     device->pub.connection = EGC_CONNECTION_DISCONNECTED;
@@ -281,7 +251,7 @@ static void wii_device_free(wii_device_t *device)
  * the worker thread */
 int change_notify_cb(int result, void *userdata)
 {
-    MQ_Send(s_worker_queue, MSG_UPDATE_DEVICES_LIST, MQ_MSG_NOBLOCK);
+    KMailboxTrySend(&s_worker_queue, MSG_UPDATE_DEVICES_LIST);
     return result;
 }
 
@@ -318,7 +288,7 @@ static int update_device_list(void)
                      " got disconnected\n",
                      device->usb.dev.vid, device->usb.dev.pid, device->usb.dev.device_id);
 
-            if (!queue_event(EGC_EVENT_DEVICE_REMOVED, device)) {
+            if (!report_event(WII_EVENT_DEVICE_REMOVED, device)) {
                 /* We normally mark the device as not valid only after the
                  * client has retrieved the event, but since we couldn't add
                  * the event into the queue, let's mark the device as available
@@ -360,12 +330,11 @@ static int update_device_list(void)
         }
 
         /* We have ownership, populate the device info */
-        LWP_MutexInit(&device->next_input_mutex, false);
-        device->timer_id = 0;
+        memset(&device->timer_task, 0, sizeof(device->timer_task));
         device->timer_callback = NULL;
         device->pub.connection = EGC_CONNECTION_USB;
 
-        queue_event(EGC_EVENT_DEVICE_ADDED, device);
+        report_event(WII_EVENT_DEVICE_ADDED, device);
     }
 
     /* Continue watching for device changes */
@@ -374,25 +343,42 @@ static int update_device_list(void)
     return 0;
 }
 
-static void *worker_thread(void *unused)
+static void process_events_timeout(KTickTask *)
+{
+    KMailboxTrySend(&s_worker_queue, (uptr)process_events_timeout);
+}
+
+static int process_events(u32 timeout_us)
 {
     bool done = false;
+    int count = 0;
 
-    update_device_list();
+    KTickTask timer;
+    if (timeout_us != 0) {
+        u64 timeout_ticks = PPCUsToTicks(timeout_us);
+        KTickTaskStart(&timer, process_events_timeout, timeout_ticks, 0);
+    }
 
     while (!done) {
-        mqmsg_t message;
+        uptr message;
 
-        bool ok = MQ_Receive(s_worker_queue, &message, MQ_MSG_BLOCK);
-        if (!ok) {
-            /* Try again? */
-            continue;
+        if (!KMailboxTryRecv(&s_worker_queue, &message)) {
+            if (timeout_us != 0) {
+                message = KMailboxRecv(&s_worker_queue);
+                done = true;
+            } else {
+                break;
+            }
         }
 
         if (message == MSG_UPDATE_DEVICES_LIST) {
+            count++;
             update_device_list();
+        } else if (message == (uptr)process_events_timeout) {
+            done = true;
         } else if (message >= MSG_FROM_TRANSFER(&s_transfers[0]) &&
                    message <= MSG_FROM_TRANSFER(&s_transfers[ARRAY_SIZE(s_transfers) - 1])) {
+            count++;
             /* It's a transfer reply */
             for (int i = 0; i < ARRAY_SIZE(s_transfers); i++) {
                 wii_transfer_t *transfer = &s_transfers[i];
@@ -414,18 +400,22 @@ static void *worker_thread(void *unused)
                 wii_device_t *device = &s_devices[i];
                 if (device->pub.connection == EGC_CONNECTION_DISCONNECTED)
                     continue;
-                if (message == &device->timer_id) {
+                if (message == (uptr)&device->timer_task) {
+                    count++;
                     LOG_INFO("%s:%d timer on %p\n", __func__, __LINE__, device);
                     bool keep = device->timer_callback(&device->pub);
                     if (!keep) {
-                        SYS_RemoveAlarm(device->timer_id);
-                        device->timer_id = 0;
+                        KTickTaskStop(&device->timer_task);
                     }
                 }
             }
         }
     }
-    return NULL;
+
+    if (timeout_us != 0) {
+        KTickTaskStop(&timer);
+    }
+    return count;
 }
 
 static int wii_init(egc_event_cb event_handler)
@@ -438,21 +428,12 @@ static int wii_init(egc_event_cb event_handler)
     if (rc != USB_OK)
         return -1;
 
-    rc = MQ_Init(&s_worker_queue, 10);
-    if (rc != MQ_ERROR_SUCCESSFUL)
-        return -1;
-
-    rc = LWP_MutexInit(&s_event_queue_mutex, false);
-    if (rc != 0)
-        return -1;
+    KMailboxPrepare(&s_worker_queue, s_worker_queue_slots, ARRAY_SIZE(s_worker_queue_slots));
 
     for (int i = 0; i < ARRAY_SIZE(s_devices); i++)
         s_devices[i].pub.connection = EGC_CONNECTION_DISCONNECTED;
 
-    /* Give our thread a little more priority than the default */
-    u8 priority = (LWP_PRIO_IDLE + LWP_PRIO_HIGHEST) / 4;
-    rc = LWP_CreateThread(&s_worker_thread, worker_thread, NULL, NULL, 0, priority);
-    return rc == 0 ? 0 : -1;
+    return update_device_list();
 }
 
 static egc_device_description_t *wii_alloc_desc(egc_input_device_t *device)
@@ -488,44 +469,14 @@ static int wii_set_suspended(egc_input_device_t *input_device, bool suspended)
 static int wii_report_input(egc_input_device_t *input_device, const egc_input_state_t *state)
 {
     wii_device_t *device = (wii_device_t *)input_device;
-    LWP_MutexLock(device->next_input_mutex);
     memcpy(&device->next_input, state, sizeof(*state));
-    LWP_MutexUnlock(device->next_input_mutex);
-    queue_event(WII_EVENT_GOT_INPUT, device);
+    report_event(WII_EVENT_GOT_INPUT, device);
     return 0;
 }
 
-static int wii_handle_events()
+static int wii_wait_events(u32 timeout_us)
 {
-    wii_event_queue_t queue;
-    /* Create a copy of the queue to ensure it doesn't get modified while we
-     * process it */
-    LWP_MutexLock(s_event_queue_mutex);
-    memcpy(&queue, &s_event_queue, sizeof(queue));
-    s_event_queue.current_index = 0; /* empty the queue */
-    LWP_MutexUnlock(s_event_queue_mutex);
-
-    for (int i = 0; i < queue.current_index; i++) {
-        struct wii_event_t *event = &queue.events[i];
-        wii_device_t *device = &s_devices[event->device_index];
-
-        if (event->type == WII_EVENT_DEVICE_ADDED) {
-            int ret = s_event_handler(&device->pub, EGC_EVENT_DEVICE_ADDED, device->usb.dev.vid,
-                                      device->usb.dev.pid);
-            if (ret != 0) {
-                wii_device_free(device);
-            }
-        } else if (event->type == WII_EVENT_DEVICE_REMOVED) {
-            s_event_handler(&device->pub, EGC_EVENT_DEVICE_REMOVED);
-            /* Mark this device as not valid */
-            wii_device_free(device);
-        } else if (event->type == WII_EVENT_GOT_INPUT) {
-            LWP_MutexLock(device->next_input_mutex);
-            memcpy(&device->pub.state, &device->next_input, sizeof(device->next_input));
-            LWP_MutexUnlock(device->next_input_mutex);
-        }
-    }
-    return queue.current_index;
+    return process_events(timeout_us);
 }
 
 const egc_platform_backend_t _egc_platform_backend = {
@@ -539,5 +490,5 @@ const egc_platform_backend_t _egc_platform_backend = {
     .alloc_desc = wii_alloc_desc,
     .set_timer = wii_set_timer,
     .report_input = wii_report_input,
-    .handle_events = wii_handle_events,
+    .wait_events = wii_wait_events,
 };

--- a/embedded-game-controller/egc.c
+++ b/embedded-game-controller/egc.c
@@ -178,7 +178,7 @@ static int on_device_removed(egc_input_device_t *device)
     if (s_device_removed_cb)
         s_device_removed_cb(device, s_callbacks_userdata);
 
-    if (device->driver->disconnect)
+    if (device->driver && device->driver->disconnect)
         rc = device->driver->disconnect(device);
 
     return rc;

--- a/embedded-game-controller/egc.c
+++ b/embedded-game-controller/egc.c
@@ -223,5 +223,10 @@ int egc_input_device_set_suspended(egc_input_device_t *device, bool suspended)
 
 int egc_handle_events()
 {
-    return _egc_platform_backend.handle_events();
+    return _egc_platform_backend.wait_events(0);
+}
+
+int egc_wait_events(u32 timeout_us)
+{
+    return _egc_platform_backend.wait_events(timeout_us);
 }

--- a/embedded-game-controller/egc.h
+++ b/embedded-game-controller/egc.h
@@ -145,5 +145,7 @@ int egc_input_device_set_suspended(egc_input_device_t *device, bool suspended);
 
 /* Fetch events and invoke callbacks. */
 int egc_handle_events(void);
+/* Fetch events and invoke callbacks. Wait up to \a timeout_us microseconds for new events. */
+int egc_wait_events(u32 timeout_us);
 
 #endif

--- a/embedded-game-controller/platform.h
+++ b/embedded-game-controller/platform.h
@@ -31,7 +31,7 @@ typedef struct egc_platform_backend_t {
     int (*report_input)(egc_input_device_t *device, const egc_input_state_t *state);
 
     /* All callbacks should be invoked in the context of this call */
-    int (*handle_events)(void);
+    int (*wait_events)(u32 timeout_us);
 } egc_platform_backend_t;
 
 extern const egc_platform_backend_t _egc_platform_backend;

--- a/example/main.c
+++ b/example/main.c
@@ -140,7 +140,8 @@ static void on_device_added(egc_input_device_t *device, void *userdata)
 
 static void on_device_removed(egc_input_device_t *device, void *userdata)
 {
-    if (!device->desc) return;
+    if (!device->desc)
+        return;
 
     bool removed = false;
     for (int i = 0; i < MAX_DEVICES; i++) {
@@ -169,7 +170,7 @@ int main(int argc, char **argv)
     int rc = egc_initialize(on_device_added, on_device_removed, NULL);
     printf("egc_initialize returned %d\n", rc);
     while (!quit_requested) {
-        egc_handle_events();
+        egc_wait_events(1000000);
 
         for (int i = 0; i < MAX_DEVICES; i++) {
             egc_input_device_t *device = s_devices[i];
@@ -179,7 +180,6 @@ int main(int argc, char **argv)
             if (device->state.gamepad.buttons)
                 print_status(device);
         }
-        usleep(1000);
     }
 
     return EXIT_SUCCESS;

--- a/example/main.c
+++ b/example/main.c
@@ -140,6 +140,8 @@ static void on_device_added(egc_input_device_t *device, void *userdata)
 
 static void on_device_removed(egc_input_device_t *device, void *userdata)
 {
+    if (!device->desc) return;
+
     bool removed = false;
     for (int i = 0; i < MAX_DEVICES; i++) {
         if (s_devices[i] == device) {


### PR DESCRIPTION
Just checking for events and sleeping for a fixed amount of time is not optimal in all cases, so add a egc_wait_events() function that waits up to the given amount of microseconds before giving up. This is inspired by libusb, select(), poll(), etc.

Update the backends to provide such a function. It turns out that we can get rid of the threads, which simplifies the code considerably. Now events are posted from the interrupts into a message queue, and retrieve directly from the main thread.

This changes has been tested with fakemote, no issues have been found.