### PR TITLE
egc: add gyroscope support, rework input API

### DIFF
--- a/embedded-game-controller/driver_api.h
+++ b/embedded-game-controller/driver_api.h
@@ -125,6 +125,53 @@ u16 egc_device_driver_parse_report(const void *raw_report, const u8 *elements,
                                    struct egc_input_state_t *state);
 void egc_device_driver_fill_desc(egc_device_description_t *desc, const u8 *elements);
 
+static inline void egc_device_driver_set_buttons(struct egc_input_state_t *state, u32 buttons)
+{
+    *(u32 *)state->bytes |= buttons;
+}
+
+static inline void egc_device_driver_set_button(struct egc_input_state_t *state,
+                                                egc_gamepad_button_e button)
+{
+    egc_device_driver_set_buttons(state, 1 << button);
+}
+
+static inline void egc_device_driver_set_axis(struct egc_input_state_t *state,
+                                              egc_gamepad_axis_e axis, s16 value)
+{
+    s16 *axes = (s16 *)(state->bytes + _EGC_STATE_OFFSET_AXES);
+    axes[axis] = value;
+}
+
+static inline egc_accelerometer_t *
+egc_device_driver_get_accelerometer(egc_input_device_t *device, struct egc_input_state_t *state,
+                                    int index)
+{
+    egc_accelerometer_t *accel = (egc_accelerometer_t *)(state->bytes + _EGC_STATE_OFFSET_ACCEL);
+    return &accel[index];
+}
+
+static inline egc_gyroscope_t *egc_device_driver_get_gyroscope(egc_input_device_t *device,
+                                                               struct egc_input_state_t *state,
+                                                               int index)
+{
+    egc_gyroscope_t *gyro =
+        (egc_gyroscope_t *)(state->bytes + _EGC_STATE_OFFSET_ACCEL +
+                            sizeof(egc_accelerometer_t) * device->desc->num_accelerometers);
+    return &gyro[index];
+}
+
+static inline void egc_device_driver_set_touch_point(egc_input_device_t *device,
+                                                     struct egc_input_state_t *state, int index,
+                                                     egc_point_t point)
+{
+    egc_point_t *points =
+        (egc_point_t *)(state->bytes + _EGC_STATE_OFFSET_ACCEL +
+                        sizeof(egc_accelerometer_t) * device->desc->num_accelerometers +
+                        sizeof(egc_gyroscope_t) * device->desc->num_gyroscopes);
+    points[index] = point;
+}
+
 extern const egc_device_driver_t ds3_usb_device_driver;
 extern const egc_device_driver_t ds4_usb_device_driver;
 extern const egc_device_driver_t dr_usb_device_driver;

--- a/embedded-game-controller/egc.c
+++ b/embedded-game-controller/egc.c
@@ -264,11 +264,13 @@ u16 egc_device_driver_parse_report(const void *raw_report, const u8 *elements,
                 int bit_offset = offset % 8;
                 bool down = (b & (1 << (7 - (bit_offset + i)))) != 0;
                 if (code == EGC_GAMEPAD_BUTTON_LEFT_TRIGGER) {
-                    state->gamepad.axes[EGC_GAMEPAD_AXIS_LEFT_TRIGGER] = down * INT16_MAX;
+                    egc_device_driver_set_axis(state, EGC_GAMEPAD_AXIS_LEFT_TRIGGER,
+                                               down * INT16_MAX);
                 } else if (code == EGC_GAMEPAD_BUTTON_RIGHT_TRIGGER) {
-                    state->gamepad.axes[EGC_GAMEPAD_AXIS_RIGHT_TRIGGER] = down * INT16_MAX;
+                    egc_device_driver_set_axis(state, EGC_GAMEPAD_AXIS_RIGHT_TRIGGER,
+                                               down * INT16_MAX);
                 } else if (down) {
-                    state->gamepad.buttons |= (1 << code);
+                    egc_device_driver_set_button(state, code);
                 }
             }
             offset += 4;
@@ -279,7 +281,7 @@ u16 egc_device_driver_parse_report(const void *raw_report, const u8 *elements,
             } else {
                 b &= 0xf;
             }
-            state->gamepad.buttons |= parse_dpad(b);
+            egc_device_driver_set_buttons(state, parse_dpad(b));
             offset += 4;
         } else if (type >= EGC_INPUT_REPORT_TYPE_AXIS_FIRST &&
                    type <= EGC_INPUT_REPORT_TYPE_AXIS_LAST) {
@@ -310,18 +312,18 @@ u16 egc_device_driver_parse_report(const void *raw_report, const u8 *elements,
 
             if (axis == EGC_GAMEPAD_AXIS_DPADX) {
                 if (value < -EGC_TRIGGER_VALUE) {
-                    state->gamepad.buttons |= 1 << EGC_GAMEPAD_BUTTON_DPAD_LEFT;
+                    egc_device_driver_set_button(state, EGC_GAMEPAD_BUTTON_DPAD_LEFT);
                 } else if (value > EGC_TRIGGER_VALUE) {
-                    state->gamepad.buttons |= 1 << EGC_GAMEPAD_BUTTON_DPAD_RIGHT;
+                    egc_device_driver_set_button(state, EGC_GAMEPAD_BUTTON_DPAD_RIGHT);
                 }
             } else if (axis == EGC_GAMEPAD_AXIS_DPADY) {
                 if (value < -EGC_TRIGGER_VALUE) {
-                    state->gamepad.buttons |= 1 << EGC_GAMEPAD_BUTTON_DPAD_UP;
+                    egc_device_driver_set_button(state, EGC_GAMEPAD_BUTTON_DPAD_UP);
                 } else if (value > EGC_TRIGGER_VALUE) {
-                    state->gamepad.buttons |= 1 << EGC_GAMEPAD_BUTTON_DPAD_DOWN;
+                    egc_device_driver_set_button(state, EGC_GAMEPAD_BUTTON_DPAD_DOWN);
                 }
             } else {
-                state->gamepad.axes[axis] = value;
+                egc_device_driver_set_axis(state, axis, value);
             }
 #undef EGC_TRIGGER_VALUE
         }

--- a/embedded-game-controller/egc.h
+++ b/embedded-game-controller/egc.h
@@ -5,6 +5,8 @@
 
 #include "egc_types.h"
 
+/* Deprecated constants: the number of accelerometer, touch points, etc. is now
+ * determined by the available place in the egc_input_state_t structure. */
 #define EGC_MAX_ACCELEROMETERS 2
 #define EGC_MAX_TOUCH_POINTS   2
 
@@ -91,6 +93,21 @@ typedef struct {
 } ATTRIBUTE_PACKED egc_accelerometer_t;
 static_assert(sizeof(egc_accelerometer_t) == 6);
 
+/* For the gyroscope we reuse the same structure as the accelerometer, and the
+ * meaning of the x, y, z members is the angular speed around the omonymous
+ * axis, expressed in 1 / EGC_GYROSCOPE_RES of radians per second. That is, a
+ * the value of EGC_GYROSCOPE_RES means a rotation of 1 radian per second.
+ *
+ * The orientation is the same defined in libSDL: the rotation is positive when
+ * the device is rotating counter-clockwise from the poing of view of an
+ * observer staying on a point on the positive direction of the axis. That is
+ * from the point of view of user holding the controller:
+ * - x: observer placed on the right of the device
+ * - y: observer placed above the device
+ * - z: observer is the user
+ */
+typedef egc_accelerometer_t egc_gyroscope_t;
+
 /* Range is 0-32767. A negative x means that there is no touch */
 #define EGC_GAMEPAD_TOUCH_RES 0x7fff
 
@@ -104,12 +121,20 @@ typedef struct egc_input_state_t {
     /* TODO: maybe add a timestamp or a counter, to let the client know if the
      * data was updated? */
     union {
+        u8 bytes[sizeof(u32) /* buttons */
+                 + sizeof(s16) * EGC_GAMEPAD_AXIS_COUNT
+                 /* This composition is just an example to give an idea of what data
+                  * can fit; the actual composition is given by the `num_*` members
+                  * of the egc_device_description_t structure */
+                 + sizeof(egc_accelerometer_t) * 2 + sizeof(egc_gyroscope_t) +
+                 sizeof(egc_point_t) * 2];
+
         struct {
             u32 buttons;
             s16 axes[EGC_GAMEPAD_AXIS_COUNT] ATTRIBUTE_ALIGN(2);
             egc_accelerometer_t accelerometer[EGC_MAX_ACCELEROMETERS];
             egc_point_t touch_points[EGC_MAX_TOUCH_POINTS];
-        } ATTRIBUTE_PACKED gamepad;
+        } ATTRIBUTE_PACKED gamepad ATTRIBUTE_DEPRECATED;
         /* TODO: add struct for guitar and drums */
     };
 } egc_input_state_t;
@@ -128,8 +153,9 @@ typedef struct egc_device_description_t {
     u32 available_axes;    /* bitmask indexed by egc_gamepad_axis_e */
     egc_device_type_e type;
     u8 num_touch_points;
-    u8 num_leds;
     u8 num_accelerometers;
+    u8 num_gyroscopes;
+    u8 num_leds;
     bool has_rumble;
 } ATTRIBUTE_PACKED egc_device_description_t;
 
@@ -148,6 +174,47 @@ int egc_input_device_resume(egc_input_device_t *device);
 /* led_state is a bit mask of the active leds */
 int egc_input_device_set_leds(egc_input_device_t *device, u32 led_state);
 int egc_input_device_set_rumble(egc_input_device_t *device, u32 intensity);
+
+/* These macros are for internal use */
+#define _EGC_STATE_OFFSET_AXES  sizeof(u32)
+#define _EGC_STATE_OFFSET_ACCEL (_EGC_STATE_OFFSET_AXES + sizeof(s16) * EGC_GAMEPAD_AXIS_COUNT)
+
+static inline u32 egc_device_read_buttons(egc_input_device_t *device)
+{
+    return *(u32 *)device->state.bytes;
+}
+
+static inline s16 egc_device_read_axis(egc_input_device_t *device, egc_gamepad_axis_e axis)
+{
+    s16 *axes = (s16 *)(device->state.bytes + _EGC_STATE_OFFSET_AXES);
+    return axes[axis];
+}
+
+static inline const egc_accelerometer_t *egc_device_read_accelerometer(egc_input_device_t *device,
+                                                                       int index)
+{
+    egc_accelerometer_t *accel =
+        (egc_accelerometer_t *)(device->state.bytes + _EGC_STATE_OFFSET_ACCEL);
+    return &accel[index];
+}
+
+static inline const egc_gyroscope_t *egc_device_read_gyroscope(egc_input_device_t *device,
+                                                               int index)
+{
+    egc_gyroscope_t *gyro =
+        (egc_gyroscope_t *)(device->state.bytes + _EGC_STATE_OFFSET_ACCEL +
+                            sizeof(egc_accelerometer_t) * device->desc->num_accelerometers);
+    return &gyro[index];
+}
+
+static inline egc_point_t egc_device_read_touch_point(egc_input_device_t *device, int index)
+{
+    egc_point_t *points =
+        (egc_point_t *)(device->state.bytes + _EGC_STATE_OFFSET_ACCEL +
+                        sizeof(egc_accelerometer_t) * device->desc->num_accelerometers +
+                        sizeof(egc_gyroscope_t) * device->desc->num_gyroscopes);
+    return points[index];
+}
 
 /* Note: suspending might not be supported by all backends */
 int egc_input_device_set_suspended(egc_input_device_t *device, bool suspended);

--- a/embedded-game-controller/egc_types.h
+++ b/embedded-game-controller/egc_types.h
@@ -21,4 +21,8 @@ typedef uint32_t u32;
 #define ATTRIBUTE_PACKED __attribute__((packed))
 #endif
 
+#ifndef ATTRIBUTE_DEPRECATED
+#define ATTRIBUTE_DEPRECATED __attribute__((deprecated))
+#endif
+
 #endif

--- a/embedded-game-controller/usb_drivers/nintendo_switch.c
+++ b/embedded-game-controller/usb_drivers/nintendo_switch.c
@@ -482,47 +482,42 @@ static bool parse_input_report(egc_input_device_t *device, const ns_input_report
         EGC_WARN("report ID: %02x", report->id);
         return false;
     }
+    s16 axes[2];
     u32 buttons = ns_get_buttons(report->button_status);
-    egc_accelerometer_t *accel = &state->gamepad.accelerometer[0];
+    egc_accelerometer_t *accel = egc_device_driver_get_accelerometer(device, state, 0);
     ns_get_accel(priv, report, accel);
     if (device->desc->product_id == NS_PID_PRO) {
-        state->gamepad.buttons =
-            egc_device_driver_map_buttons(buttons, NS_BUTTON_COUNT, s_button_map_pro);
-        ns_get_analog_axis(report->left_stick, &state->gamepad.axes[NS_ANALOG_AXIS_LEFT_X],
-                           priv->stick_cal_left);
-        state->gamepad.axes[NS_ANALOG_AXIS_LEFT_Y] =
-            -1 - state->gamepad.axes[NS_ANALOG_AXIS_LEFT_Y];
-        ns_get_analog_axis(report->right_stick, &state->gamepad.axes[NS_ANALOG_AXIS_RIGHT_X],
-                           priv->stick_cal_right);
-        state->gamepad.axes[NS_ANALOG_AXIS_RIGHT_Y] =
-            -1 - state->gamepad.axes[NS_ANALOG_AXIS_RIGHT_Y];
-        state->gamepad.axes[EGC_GAMEPAD_AXIS_LEFT_TRIGGER] =
-            ((buttons >> NS_BUTTON_ZL) & 1) * INT16_MAX;
-        state->gamepad.axes[EGC_GAMEPAD_AXIS_RIGHT_TRIGGER] =
-            ((buttons >> NS_BUTTON_ZR) & 1) * INT16_MAX;
+        egc_device_driver_set_buttons(
+            state, egc_device_driver_map_buttons(buttons, NS_BUTTON_COUNT, s_button_map_pro));
+        ns_get_analog_axis(report->left_stick, axes, priv->stick_cal_left);
+        egc_device_driver_set_axis(state, EGC_GAMEPAD_AXIS_LEFTX, axes[0]);
+        egc_device_driver_set_axis(state, EGC_GAMEPAD_AXIS_LEFTY, -1 - axes[1]);
+        ns_get_analog_axis(report->right_stick, axes, priv->stick_cal_right);
+        egc_device_driver_set_axis(state, EGC_GAMEPAD_AXIS_RIGHTX, axes[0]);
+        egc_device_driver_set_axis(state, EGC_GAMEPAD_AXIS_LEFTY, -1 - axes[1]);
+
+        egc_device_driver_set_axis(state, EGC_GAMEPAD_AXIS_LEFT_TRIGGER,
+                                   ((buttons >> NS_BUTTON_ZL) & 1) * INT16_MAX);
+        egc_device_driver_set_axis(state, EGC_GAMEPAD_AXIS_RIGHT_TRIGGER,
+                                   ((buttons >> NS_BUTTON_ZR) & 1) * INT16_MAX);
     } else if (device->desc->product_id == NS_PID_LJC) {
-        state->gamepad.buttons =
-            egc_device_driver_map_buttons(buttons, NS_BUTTON_COUNT, s_button_map_ljc);
-        ns_get_analog_axis(report->left_stick, &state->gamepad.axes[NS_ANALOG_AXIS_LEFT_X],
-                           priv->stick_cal_left);
+        egc_device_driver_set_buttons(
+            state, egc_device_driver_map_buttons(buttons, NS_BUTTON_COUNT, s_button_map_ljc));
+        ns_get_analog_axis(report->left_stick, axes, priv->stick_cal_left);
         /* Adjust for rotation */
-        s16 original_x = state->gamepad.axes[NS_ANALOG_AXIS_LEFT_X];
-        state->gamepad.axes[NS_ANALOG_AXIS_LEFT_X] =
-            -1 - state->gamepad.axes[NS_ANALOG_AXIS_LEFT_Y];
-        state->gamepad.axes[NS_ANALOG_AXIS_LEFT_Y] = -1 - original_x;
+        egc_device_driver_set_axis(state, EGC_GAMEPAD_AXIS_LEFTX, -1 - axes[1]);
+        egc_device_driver_set_axis(state, EGC_GAMEPAD_AXIS_LEFTY, -1 - axes[0]);
 
         float tmp = accel->x;
         accel->x = accel->z;
         accel->z = -tmp;
     } else if (device->desc->product_id == NS_PID_RJC) {
-        state->gamepad.buttons =
-            egc_device_driver_map_buttons(buttons, NS_BUTTON_COUNT, s_button_map_rjc);
-        ns_get_analog_axis(report->right_stick, &state->gamepad.axes[NS_ANALOG_AXIS_LEFT_X],
-                           priv->stick_cal_right);
+        egc_device_driver_set_buttons(
+            state, egc_device_driver_map_buttons(buttons, NS_BUTTON_COUNT, s_button_map_rjc));
+        ns_get_analog_axis(report->right_stick, axes, priv->stick_cal_right);
         /* Adjust for rotation */
-        s16 original_x = state->gamepad.axes[NS_ANALOG_AXIS_LEFT_X];
-        state->gamepad.axes[NS_ANALOG_AXIS_LEFT_X] = state->gamepad.axes[NS_ANALOG_AXIS_LEFT_Y];
-        state->gamepad.axes[NS_ANALOG_AXIS_LEFT_Y] = original_x;
+        egc_device_driver_set_axis(state, EGC_GAMEPAD_AXIS_LEFTX, axes[1]);
+        egc_device_driver_set_axis(state, EGC_GAMEPAD_AXIS_LEFTY, axes[0]);
         float tmp = accel->x;
         accel->x = -accel->z;
         accel->z = -tmp;

--- a/embedded-game-controller/usb_drivers/sony_ds3.c
+++ b/embedded-game-controller/usb_drivers/sony_ds3.c
@@ -220,20 +220,25 @@ static void ds3_get_report_cb(egc_usb_transfer_t *transfer)
 
     if (transfer->status == EGC_USB_TRANSFER_STATUS_COMPLETED) {
         u32 buttons = ds3_get_buttons(report);
-        state.gamepad.buttons =
-            egc_device_driver_map_buttons(buttons, DS3_BUTTON_COUNT, s_button_map);
+        egc_device_driver_set_buttons(
+            &state, egc_device_driver_map_buttons(buttons, DS3_BUTTON_COUNT, s_button_map));
 
         u8 axes[DS3_ANALOG_AXIS_COUNT];
         ds3_get_analog_axis(report, axes);
-        state.gamepad.axes[EGC_GAMEPAD_AXIS_LEFTX] = egc_u8_to_s16(axes[DS3_ANALOG_AXIS_LEFT_X]);
-        state.gamepad.axes[EGC_GAMEPAD_AXIS_LEFTY] = egc_u8_to_s16(axes[DS3_ANALOG_AXIS_LEFT_Y]);
-        state.gamepad.axes[EGC_GAMEPAD_AXIS_RIGHTX] = egc_u8_to_s16(axes[DS3_ANALOG_AXIS_RIGHT_X]);
-        state.gamepad.axes[EGC_GAMEPAD_AXIS_RIGHTY] = egc_u8_to_s16(axes[DS3_ANALOG_AXIS_RIGHT_Y]);
+        egc_device_driver_set_axis(&state, EGC_GAMEPAD_AXIS_LEFTX,
+                                   egc_u8_to_s16(axes[DS3_ANALOG_AXIS_LEFT_X]));
+        egc_device_driver_set_axis(&state, EGC_GAMEPAD_AXIS_LEFTY,
+                                   egc_u8_to_s16(axes[DS3_ANALOG_AXIS_LEFT_Y]));
+        egc_device_driver_set_axis(&state, EGC_GAMEPAD_AXIS_RIGHTX,
+                                   egc_u8_to_s16(axes[DS3_ANALOG_AXIS_RIGHT_X]));
+        egc_device_driver_set_axis(&state, EGC_GAMEPAD_AXIS_RIGHTY,
+                                   egc_u8_to_s16(axes[DS3_ANALOG_AXIS_RIGHT_Y]));
 
+        egc_accelerometer_t *accel = egc_device_driver_get_accelerometer(device, &state, 0);
 #define MAP_ACCEL(v) ((v) * EGC_ACCELEROMETER_RES_PER_G / DS3_ACC_RES_PER_G)
-        state.gamepad.accelerometer[0].x = MAP_ACCEL((s16)report->acc_x - 511);
-        state.gamepad.accelerometer[0].y = MAP_ACCEL(511 - (s16)report->acc_y);
-        state.gamepad.accelerometer[0].z = MAP_ACCEL(511 - (s16)report->acc_z);
+        accel->x = MAP_ACCEL((s16)report->acc_x - 511);
+        accel->y = MAP_ACCEL(511 - (s16)report->acc_y);
+        accel->z = MAP_ACCEL(511 - (s16)report->acc_z);
 #undef MAP_ACCEL
 
         egc_device_driver_report_input(device, &state);

--- a/embedded-game-controller/usb_drivers/sony_ds4.c
+++ b/embedded-game-controller/usb_drivers/sony_ds4.c
@@ -256,41 +256,45 @@ static void ds4_parse_input_report(egc_input_device_t *device,
 
     if (report->report_id == 0x01) {
         u32 buttons = ds4_get_buttons(report);
-        state.gamepad.buttons =
-            egc_device_driver_map_buttons(buttons, DS4_BUTTON_COUNT, s_button_map);
+        egc_device_driver_set_buttons(
+            &state, egc_device_driver_map_buttons(buttons, DS4_BUTTON_COUNT, s_button_map));
 
         u8 axes[DS4_ANALOG_AXIS_COUNT];
         ds4_get_analog_axis(report, axes);
-        state.gamepad.axes[EGC_GAMEPAD_AXIS_LEFTX] = egc_u8_to_s16(axes[DS4_ANALOG_AXIS_LEFT_X]);
-        state.gamepad.axes[EGC_GAMEPAD_AXIS_LEFTY] = egc_u8_to_s16(axes[DS4_ANALOG_AXIS_LEFT_Y]);
-        state.gamepad.axes[EGC_GAMEPAD_AXIS_RIGHTX] = egc_u8_to_s16(axes[DS4_ANALOG_AXIS_RIGHT_X]);
-        state.gamepad.axes[EGC_GAMEPAD_AXIS_RIGHTY] = egc_u8_to_s16(axes[DS4_ANALOG_AXIS_RIGHT_Y]);
+        egc_device_driver_set_axis(&state, EGC_GAMEPAD_AXIS_LEFTX,
+                                   egc_u8_to_s16(axes[DS4_ANALOG_AXIS_LEFT_X]));
+        egc_device_driver_set_axis(&state, EGC_GAMEPAD_AXIS_LEFTY,
+                                   egc_u8_to_s16(axes[DS4_ANALOG_AXIS_LEFT_Y]));
+        egc_device_driver_set_axis(&state, EGC_GAMEPAD_AXIS_RIGHTX,
+                                   egc_u8_to_s16(axes[DS4_ANALOG_AXIS_RIGHT_X]));
+        egc_device_driver_set_axis(&state, EGC_GAMEPAD_AXIS_RIGHTY,
+                                   egc_u8_to_s16(axes[DS4_ANALOG_AXIS_RIGHT_Y]));
 
+        egc_accelerometer_t *accel = egc_device_driver_get_accelerometer(device, &state, 0);
 #define MAP_ACCEL(v) ((s16)le16toh(v) * EGC_ACCELEROMETER_RES_PER_G / DS4_ACC_RES_PER_G)
-        state.gamepad.accelerometer[0].x = -MAP_ACCEL(report->accel_x);
-        state.gamepad.accelerometer[0].y = MAP_ACCEL(report->accel_y);
-        state.gamepad.accelerometer[0].z = MAP_ACCEL(report->accel_z);
+        accel->x = -MAP_ACCEL(report->accel_x);
+        accel->y = MAP_ACCEL(report->accel_y);
+        accel->z = MAP_ACCEL(report->accel_z);
 #undef MAP_ACCEL
 
 #define MAP_TOUCH_X(v) ((v) * EGC_GAMEPAD_TOUCH_RES / DS4_TOUCHPAD_W)
 #define MAP_TOUCH_Y(v) ((v) * EGC_GAMEPAD_TOUCH_RES / DS4_TOUCHPAD_H)
+        egc_point_t point;
         if (!report->finger1_nactive) {
-            state.gamepad.touch_points[0].x =
-                MAP_TOUCH_X(report->finger1_x_lo | ((u16)report->finger1_x_hi << 8));
-            state.gamepad.touch_points[0].y =
-                MAP_TOUCH_Y(report->finger1_y_lo | ((u16)report->finger1_y_hi << 4));
+            point.x = MAP_TOUCH_X(report->finger1_x_lo | ((u16)report->finger1_x_hi << 8));
+            point.y = MAP_TOUCH_Y(report->finger1_y_lo | ((u16)report->finger1_y_hi << 4));
         } else {
-            state.gamepad.touch_points[0].x = -1;
+            point.x = -1;
         }
+        egc_device_driver_set_touch_point(device, &state, 0, point);
 
         if (!report->finger2_nactive) {
-            state.gamepad.touch_points[1].x =
-                MAP_TOUCH_X(report->finger2_x_lo | ((u16)report->finger2_x_hi << 8));
-            state.gamepad.touch_points[1].y =
-                MAP_TOUCH_Y(report->finger2_y_lo | ((u16)report->finger2_y_hi << 4));
+            point.x = MAP_TOUCH_X(report->finger2_x_lo | ((u16)report->finger2_x_hi << 8));
+            point.y = MAP_TOUCH_Y(report->finger2_y_lo | ((u16)report->finger2_y_hi << 4));
         } else {
-            state.gamepad.touch_points[1].x = -1;
+            point.x = -1;
         }
+        egc_device_driver_set_touch_point(device, &state, 1, point);
 #undef MAP_TOUCH_X
 #undef MAP_TOUCH_Y
 

--- a/example/main.c
+++ b/example/main.c
@@ -12,7 +12,7 @@ static egc_input_device_t *s_devices[MAX_DEVICES];
 
 static void print_status(egc_input_device_t *device)
 {
-    u32 buttons = device->state.gamepad.buttons;
+    u32 buttons = egc_device_read_buttons(device);
 
 #define PRESSED(b) (buttons & (1 << b))
     if (PRESSED(EGC_GAMEPAD_BUTTON_SOUTH)) {
@@ -98,25 +98,25 @@ static void print_status(egc_input_device_t *device)
 
 #define HAS_AXIS(x) (device->desc->available_axes & (1 << x))
     if (HAS_AXIS(EGC_GAMEPAD_AXIS_LEFTX)) {
-        printf("L stick: %d,%d ", device->state.gamepad.axes[EGC_GAMEPAD_AXIS_LEFTX],
-               device->state.gamepad.axes[EGC_GAMEPAD_AXIS_LEFTY]);
+        printf("L stick: %d,%d ", egc_device_read_axis(device, EGC_GAMEPAD_AXIS_LEFTX),
+               egc_device_read_axis(device, EGC_GAMEPAD_AXIS_LEFTY));
     }
 
     if (HAS_AXIS(EGC_GAMEPAD_AXIS_RIGHTX)) {
-        printf("R stick: %d,%d ", device->state.gamepad.axes[EGC_GAMEPAD_AXIS_RIGHTX],
-               device->state.gamepad.axes[EGC_GAMEPAD_AXIS_RIGHTY]);
+        printf("R stick: %d,%d ", egc_device_read_axis(device, EGC_GAMEPAD_AXIS_RIGHTX),
+               egc_device_read_axis(device, EGC_GAMEPAD_AXIS_RIGHTY));
     }
 
     if (HAS_AXIS(EGC_GAMEPAD_AXIS_LEFT_TRIGGER)) {
-        printf("L trigger: %d ", device->state.gamepad.axes[EGC_GAMEPAD_AXIS_LEFT_TRIGGER]);
+        printf("L trigger: %d ", egc_device_read_axis(device, EGC_GAMEPAD_AXIS_LEFT_TRIGGER));
     }
 
     if (HAS_AXIS(EGC_GAMEPAD_AXIS_RIGHT_TRIGGER)) {
-        printf("R trigger: %d ", device->state.gamepad.axes[EGC_GAMEPAD_AXIS_RIGHT_TRIGGER]);
+        printf("R trigger: %d ", egc_device_read_axis(device, EGC_GAMEPAD_AXIS_RIGHT_TRIGGER));
     }
 
     for (int i = 0; i < device->desc->num_accelerometers; i++) {
-        egc_accelerometer_t *accel = &device->state.gamepad.accelerometer[i];
+        egc_accelerometer_t *accel = egc_device_read_accelerometer(device, i);
         printf("Accel%d (%d %d %d) ", i, accel->x, accel->y, accel->z);
     }
 
@@ -189,13 +189,14 @@ int main(int argc, char **argv)
             if (!device)
                 continue;
 
-            u32 released = previously_down & ~device->state.gamepad.buttons;
-            previously_down = device->state.gamepad.buttons;
+            u32 down = egc_device_read_buttons(device);
+            u32 released = previously_down & ~down;
+            previously_down = down;
 
-            if (device->state.gamepad.buttons)
+            if (down)
                 print_status(device);
 
-            if (device->state.gamepad.buttons & (1 << EGC_GAMEPAD_BUTTON_SOUTH)) {
+            if (down & (1 << EGC_GAMEPAD_BUTTON_SOUTH)) {
                 if (device->desc->num_leds > 0 &&
                     released & (1 << EGC_GAMEPAD_BUTTON_RIGHT_SHOULDER)) {
                     led = (led + 1) % device->desc->num_leds;
@@ -203,9 +204,7 @@ int main(int argc, char **argv)
                 }
 
                 if (device->desc->has_rumble) {
-                    u32 new_intensity =
-                        device->state.gamepad.buttons & (1 << EGC_GAMEPAD_BUTTON_LEFT_SHOULDER) ? 1
-                                                                                                : 0;
+                    u32 new_intensity = down & (1 << EGC_GAMEPAD_BUTTON_LEFT_SHOULDER) ? 1 : 0;
                     if (new_intensity != rumble_intensity) {
                         egc_input_device_set_rumble(device, new_intensity);
                         rumble_intensity = new_intensity;


### PR DESCRIPTION
Add gyroscope support in the API. Rework it a bit not to hardcode the number of accelerometers, gyroscopes and touch points, to accomodate different configurations while minimising the required space.

Deprecate the gamepad struct member, to make the egc_input_state_t structure opaque. This will allow us to change it more freely without breaking the API.