### PR TITLE
Gamecube fixes

### DIFF
--- a/embedded-game-controller/hid_drivers/gamecube.c
+++ b/embedded-game-controller/hid_drivers/gamecube.c
@@ -144,7 +144,7 @@ int _egc_gc_process_events(egc_event_cb event_handler)
             count++;
         }
 
-        if (connected) {
+        if (err == PAD_ERR_NONE) {
             /* We don't use egc_device_driver_report_input(), since we know we
              * are running in the main EGC thread and can modify the fields
              * directly */
@@ -166,7 +166,7 @@ int _egc_gc_process_events(egc_event_cb event_handler)
             egc_device_driver_set_axis(state, EGC_GAMEPAD_AXIS_RIGHT_TRIGGER,
                                        trigger_value(s_pad[i].triggerR));
             count++;
-        } else {
+        } else if (err == PAD_ERR_NO_CONTROLLER) {
             resetBits |= (PAD_CHAN0_BIT >> i);
         }
     }

--- a/example/main.c
+++ b/example/main.c
@@ -190,7 +190,9 @@ int main(int argc, char **argv)
     int led = 0;
     u32 rumble_intensity = 0;
 
-    u32 previously_down = 0;
+    u32 previously_down[MAX_DEVICES] = {
+        0,
+    };
 
     egc_bt_enter_page_mode();
     egc_bt_start_scan();
@@ -204,8 +206,8 @@ int main(int argc, char **argv)
                 continue;
 
             u32 down = egc_input_device_read_buttons(device);
-            u32 released = previously_down & ~down;
-            previously_down = down;
+            u32 released = previously_down[i] & ~down;
+            previously_down[i] = down;
 
             if (down)
                 print_status(device);


### PR DESCRIPTION
Addressing https://github.com/embedded-game-controller/embedded-game-controller/pull/26#issuecomment-4635495149

I haven't actually been able to reproduce the issue. I added the following changes to the example:

```diff
diff --git a/example/main.c b/example/main.c
index ea19e98..a9d2154 100644
--- a/example/main.c
+++ b/example/main.c
@@ -195,8 +195,9 @@ int main(int argc, char **argv)
     egc_bt_enter_page_mode();
     egc_bt_start_scan();
 
+    int num_presses = 0;
     while (!quit_requested) {
-        egc_wait_events(1000000);
+        egc_wait_events(1000);
 
         for (int i = 0; i < MAX_DEVICES; i++) {
             egc_input_device_t *device = s_devices[i];
@@ -207,6 +208,10 @@ int main(int argc, char **argv)
             u32 released = previously_down[i] & ~down;
             previously_down[i] = down;
 
+            if (released & (1 << EGC_GAMEPAD_BUTTON_SOUTH)) {
+                num_presses++;
+                printf("Presses: %d\n", num_presses);
+            }
             if (down)
                 print_status(device);
 
```

But the count appears to be correct. Anyway, the proposed change seems valid.