### PR TITLE
egc: add API to retrieve battery critical condition

### DIFF
--- a/embedded-game-controller/driver_api.h
+++ b/embedded-game-controller/driver_api.h
@@ -181,6 +181,11 @@ static inline void egc_device_driver_set_touch_point(egc_input_device_t *device,
     points[index] = point;
 }
 
+static inline void egc_device_driver_set_battery_critical(egc_input_device_t *device, bool critical)
+{
+    device->battery_critical = critical;
+}
+
 extern bool _egc_enable_accelerometer_default;
 extern bool _egc_enable_gyroscope_default;
 extern bool _egc_enable_touch_point_default;

--- a/embedded-game-controller/egc.h
+++ b/embedded-game-controller/egc.h
@@ -165,7 +165,9 @@ struct egc_input_device_t {
     const egc_device_description_t *desc;
     egc_input_state_t state ATTRIBUTE_ALIGN(4);
     egc_connection_e connection;
-    bool suspended;
+    bool suspended : 1;
+    bool battery_critical : 1;
+    u8 unused : 6;
 } ATTRIBUTE_PACKED ATTRIBUTE_ALIGN(8);
 
 typedef void (*egc_input_device_cb)(egc_input_device_t *device, void *userdata);
@@ -220,6 +222,11 @@ static inline egc_point_t egc_input_device_read_touch_point(egc_input_device_t *
                         sizeof(egc_accelerometer_t) * device->desc->num_accelerometers +
                         sizeof(egc_gyroscope_t) * device->desc->num_gyroscopes);
     return points[index];
+}
+
+static inline bool egc_input_device_is_battery_critical(egc_input_device_t *device)
+{
+    return device->battery_critical;
 }
 
 /* Functions to enable/disable sensor features. The initial status of these

--- a/embedded-game-controller/hid_drivers/nintendo_switch.c
+++ b/embedded-game-controller/hid_drivers/nintendo_switch.c
@@ -483,6 +483,8 @@ static bool parse_input_report(egc_input_device_t *device, const ns_input_report
         EGC_WARN("report ID: %02x", report->id);
         return false;
     }
+    u8 battery_level = report->bat_con >> 4;
+    egc_device_driver_set_battery_critical(device, battery_level <= 2);
     s16 axes[2];
     u32 buttons = ns_get_buttons(report->button_status);
     egc_accelerometer_t *accel = egc_device_driver_get_accelerometer(device, state, 0);

--- a/embedded-game-controller/hid_drivers/wiimote.c
+++ b/embedded-game-controller/hid_drivers/wiimote.c
@@ -1307,9 +1307,8 @@ static void wm_status_cb(egc_input_device_t *device, const u8 *data)
 
     u8 status = data[2];
     priv->leds = status >> 4;
-    /* No use for this at the moment:
-    priv->battery_critical = status & WM_STATUS_BATTERY_CRITICAL;
-    */
+    bool battery_critical = status & WM_STATUS_BATTERY_CRITICAL;
+    egc_device_driver_set_battery_critical(device, battery_critical);
     priv->exp_attached = status & WM_STATUS_EXP_ATTACHED;
     priv->ir_enabled = status & WM_STATUS_IR_ENABLED;
 


### PR DESCRIPTION
Implement it in the wiimote and Nintendo Switch drivers.